### PR TITLE
针对枚举可能是number类型的情况，区分生成Record和Map的场景

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "enum2map" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [v1.0] 
+- 区分toMap和toRecord功能
+
 ## [Unreleased]
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 安装完成并且启用插件之后
 
 定义一个枚举类型，然后全选该枚举,
-1. 按快捷键 mac: `option + m`, windows: `alt + m` 或右键菜单点击 enum2map-map，即可生成对应映射
-2. 按快捷键 mac: `option + o`, windows: `alt + o` 或右键菜单点击 enum2map-options，即可生成对应的options
+1. 按快捷键 mac: `option + m`, windows: `alt + m` 或右键菜单点击 enum2map-map，即可生成对应映射（Map）
+2. 按快捷键 mac: `option + r`, windows: `alt + r` 或右键菜单点击 enum2map-map，即可生成对应映射（Record）
+3. 按快捷键 mac: `option + o`, windows: `alt + o` 或右键菜单点击 enum2map-options，即可生成对应的options
 
 生成的option项，默认类型是 Array<{ label: string; value: Enum }>;
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "enum2map",
 	"displayName": "enum2map(enum map generator)",
 	"description": "generate mapper from enum in TS; enum2map",
-	"version": "0.0.7",
+	"version": "0.1.0",
 	"engines": {
 		"vscode": "^1.69.0"
 	},
@@ -21,6 +21,10 @@
 				"title": "enum2map-map"
 			},
 			{
+				"command": "enum2map.generateRecord",
+				"title": "enum2map-record"
+			},
+			{
 				"command": "enum2map.generateOptions",
 				"title": "enum2map-options"
 			}
@@ -29,6 +33,10 @@
 			"editor/context": [
 				{
 					"command": "enum2map.generateMap",
+					"when": "editorLangId == typescript || editorLangId == typescriptreact && editorHasSelection"
+				},
+				{
+					"command": "enum2map.generateRecord",
 					"when": "editorLangId == typescript || editorLangId == typescriptreact && editorHasSelection"
 				},
 				{
@@ -41,6 +49,11 @@
 			{
 				"command": "enum2map.generateMap",
 				"key": "alt+m",
+				"when": "editorLangId == typescript || editorLangId == typescriptreact && editorHasSelection"
+			},
+			{
+				"command": "enum2map.generateRecord",
+				"key": "alt+r",
 				"when": "editorLangId == typescript || editorLangId == typescriptreact && editorHasSelection"
 			},
 			{
@@ -98,4 +111,5 @@
 		"webpack-cli": "^4.10.0",
 		"@vscode/test-electron": "^2.1.5"
 	}
-}
+};
+

--- a/package.json
+++ b/package.json
@@ -111,5 +111,5 @@
 		"webpack-cli": "^4.10.0",
 		"@vscode/test-electron": "^2.1.5"
 	}
-};
+}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
 
-import { generateMap, generateOptions } from "./transform";
+import { generateMap, generateOptions, generateRecord } from "./transform";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -19,10 +19,17 @@ export function activate(context: vscode.ExtensionContext) {
     generateMap
   );
 
+  const disposableRecord = vscode.commands.registerCommand(
+    "enum2map.generateRecord",
+    generateRecord
+  );
+
+
   const disposableOptions = vscode.commands.registerCommand(
     "enum2map.generateOptions",
     generateOptions
   );
+  
 
   context.subscriptions.push(disposableMap, disposableOptions);
 }

--- a/src/toRecord.ts
+++ b/src/toRecord.ts
@@ -3,14 +3,14 @@ import type { SourceFile, EnumDeclaration } from "typescript";
 
 import { firstChar2lowerCase, getComment, getCommentContent } from "./utils";
 
-export function toMap(node: EnumDeclaration, sourceFile: SourceFile) {
+export function toRecord(node: EnumDeclaration, sourceFile: SourceFile) {
   const firstToken = node.getFirstToken(sourceFile)?.getFullText(sourceFile);
 
   const comment = getComment(node, sourceFile);
 
   let outputCode = `${comment ? `${comment}\n` : ""}${
     firstToken?.endsWith("export") ? "export " : ""
-  }const ${firstChar2lowerCase(node.name.text)}Map: Map<${node.name.text}, string> = new Map([`;
+  }const ${firstChar2lowerCase(node.name.text)}Record: Record<${node.name.text}, string> = {`;
 
   const members: string[] = [];
   node.forEachChild((n) => {
@@ -18,12 +18,11 @@ export function toMap(node: EnumDeclaration, sourceFile: SourceFile) {
     if (isEnumMember(n)) {
       const propertyName = n.name.getText(sourceFile);
       members.push(
-        `  [${node.name.text}.${propertyName}, '${content || propertyName}'],`
+        `  [${node.name.text}.${propertyName}]: '${content || propertyName}',`
       );
     }
   });
-  outputCode += `\n${members.join("\n")}\n])`;
+  outputCode += `\n${members.join("\n")}\n}`;
 
   return outputCode;
 }
-

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { isEnumDeclaration, createSourceFile, ScriptTarget } from "typescript";
 import type { Node, EnumDeclaration, SourceFile } from "typescript";
 
+import { toRecord } from "./toRecord";
 import { toMap } from "./toMap";
 import { toOptions } from "./toOptions";
 
@@ -59,4 +60,5 @@ function createGenerator(
 }
 
 export const generateMap = createGenerator(toMap);
+export const generateRecord = createGenerator(toRecord);
 export const generateOptions = createGenerator(toOptions);


### PR DESCRIPTION
在使用antd-pro时，表单列的valueType设置为select，并添加valueEnum，会自动生成对应的select选项，但是由于Record的key会转化为string，导致proTable的搜索值需要做额外的转换。
proTable的valueEnum本身可以接受Map类型，因此在本插件的基础上增加了转换成Record和Map两个选项，增加了更多的使用场景。